### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,7 +24,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item = Item.find(id: 1)
+    @item = Item.find(1)
     @item.destroy
     # if @item.saler_user_id == current_user.id
     #   @item.destroy

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,7 +9,6 @@ class ItemsController < ApplicationController
   def new
   end
 
-
   def update
     # 現状viewからidのvalueを送信出来ないので仮のidを入れています
     @item = Item.where(id: 1)
@@ -22,6 +21,16 @@ class ItemsController < ApplicationController
   end
 
   def edit
+  end
+
+  def destroy
+    @item = Item.find_by(id: 1)
+    @item.destroy
+    # if @item.saler_user_id == current_user.id
+    #   @item.destroy
+    # else
+    #   redirect_to controller: 'products', action: 'show', notice: "商品を削除出来ませんでした"
+    # end
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,7 +24,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item = Item.find_by(id: 1)
+    @item = Item.find(id: 1)
     @item.destroy
     # if @item.saler_user_id == current_user.id
     #   @item.destroy

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,7 +3,7 @@ class Item < ApplicationRecord
 
   belongs_to_active_hash :prefecture
   belongs_to :user, optional: true
-  has_many :images
+  has_many :images, dependent: :destroy
   has_many :evaluations
   has_many :likes
   has_many :item_comments

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,1 +1,3 @@
 =link_to '出品を停止する', item_path(@item), method: :put
+%br
+=link_to 'この商品を削除する', item_path(@item), method: :delete


### PR DESCRIPTION
### What
- 商品削除機能です。
- 出品停止と同様、まだビューからitemsのidをサーバーサイドに送る実装が出来ていないので、固定でid: 1の商品が削除されるようにしています。

### Why
- 商品削除機能の実装が完了したため。