### PR TITLE
Pay.jpを使ったクレジットカード決済機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,4 @@ gem "omniauth-rails_csrf_protection"
 gem 'dotenv-rails'
 gem 'ancestry'
 gem "gretel"
+gem "payjp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -168,6 +170,9 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
+    http-accept (1.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     image_processing (1.9.3)
@@ -212,6 +217,7 @@ GEM
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-ssh (5.2.0)
+    netrc (0.11.0)
     nio4r (2.5.2)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
@@ -237,6 +243,8 @@ GEM
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
+    payjp (0.0.7)
+      rest-client (~> 2.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -282,6 +290,11 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.0)
@@ -344,6 +357,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
     unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -394,6 +410,7 @@ DEPENDENCIES
   omniauth-facebook
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
+  payjp
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,36 +1,37 @@
-//jsファイルで入力したカード情報を取得し、payjpのサーバーと通信を行い、トークンを取得する。
-//作成されたtokenはコントローラに送る。
-document.addEventListener(
-  "DOMContentLoaded", e => {
-    if (document.getElementById("token_submit") != null) { //token_submitというidがnullの場合、下記コードを実行しない
-      Payjp.setPublicKey('PAYJP_PUBLIC_KEY'); //認証のための公開鍵をセット。setPublicKey(key)：keyは必須でstr型。
-      var btn = document.getElementById("token_submit"); //IDがtoken_submitの場合に取得される
-      btn.addEventListener("click", e => {
-        e.preventDefault(); //clickを実行してページが更新されるのを防ぐ
-        var card = {
-          number: document.getElementById("card_number").value,
-          cvc: document.getElementById("cvc").value,
-          exp_month: document.getElementById("exp_month").value,
-          exp_year: document.getElementById("exp_year").value
-        }; //入力されたデータを取得
-        Payjp.createToken(card, (status, response) => {
-          //createToken(card[, options], callback)：PAY.JPのサーバーと通信し、カード情報の認証を行い、トークンを作成。cardは必須、Object型、カード情報であり、number exp_year exp_monthが必須、cvcは任意でいずれもstr型。optionsはテナントID指定関係で今回は不要。callbackは必須、レスポンス取得時に呼ばれるコールバック関数、第1引数にHTTPステータス、第2引数にtokenオブジェクト。
-          if (status === 200) { //成功した場合
-            $("#card_number").removeAttr("name");
-            $("#cvc").removeAttr("name");
-            $("#exp_month").removeAttr("name");
-            $("#exp_year").removeAttr("name"); //以上4つのデータを自サーバにpostしないようにparamsの値として含まれないようにする
-            $("#card_token").append(
-              $('<input type="hidden" name="payjp-token">').val(response.id)
-            ); //コントローラにトークンIDをparamsとして渡せるようにする。通信が成功し、statusが200になったとき、typeがhiddenとなっているinput要素が追加される。これが値として変数tokenを取得しているのでresponse.idがコントローラでparams[:payjp-token]として受け取ることが可能になる。
-            document.inputForm.submit();
-            alert("登録が完了しました"); //確認用
-          } else {
-            alert("カード情報が正しくありません。"); //確認用
-          }
-        });
-      });
-    }
-  },
-  false
-);
+//jsファイルで入力したカード情報を取得し、payjpのサーバーと通信を行い、トークンを取得する。作成されたトークンはコントローラに送る。
+
+// DOM読み込みが完了したら実行
+document.addEventListener('DOMContentLoaded', (e) => {
+  // payjp.jsの初期化、下記は公開鍵です。setPublicKey(key)：keyは必須でstr型。
+  Payjp.setPublicKey('pk_test_b55fd2a18b0c021513c245e1');
+  
+  // ボタンのイベントハンドリング
+  var btn = document.getElementById('token');
+  btn.addEventListener('click', (e) => {
+    e.preventDefault(); //clickを実行してページが更新されるのを防ぐ
+    
+    // 入力されたカード情報を取得
+    var card = {
+      number: document.getElementById('card_number').value,
+      cvc: document.getElementById('cvc').value,
+      exp_month: document.getElementById('exp_month').value,
+      exp_year: document.getElementById('exp_year').value
+    };
+    
+    // トークン生成
+    Payjp.createToken(card, (status, response) => {
+      //createToken(card, callback)：PAY.JPのサーバーと通信し、カード情報の認証を行い、トークンを作成。cardは必須、Object型、カード情報であり、number exp_year exp_monthが必須、cvcは任意でいずれもstr型。callbackは必須、レスポンス取得時に呼ばれるコールバック関数、第1引数にHTTPステータス、第2引数にtokenオブジェクト。
+      if (status === 200) {
+        // 出力（本来はサーバへ送信）
+        document.getElementById('card_token').innerHTML = response.card.id;
+      //   $("#card_token").append(
+      //     $('<input type="hidden" name="payjp-token">').val(response.id)
+      //   ); //コントローラにトークンIDをparamsとして渡せるようにする。通信が成功し、statusが200になったとき、typeがhiddenとなっているinput要素が追加される。これが値として変数tokenを取得しているのでresponse.idがコントローラでparams[:payjp-token]として受け取ることが可能になる。
+      //   document.InputForm.submit();
+      //   alert("登録が完了しました");
+      // } else {
+      //   alert("カード情報が正しくありませんよ");
+      }
+    });
+  });
+}, false);

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', (e) => {
       
       // トークン生成
       Payjp.createToken(card, (status, response) => {
-        //createToken(card, callback)：PAY.JPのサーバーと通信し、カード情報の認証を行い、トークンを作成。cardは必須、Object型、カード情報であり、number exp_year exp_monthが必須、cvcは任意でいずれもstr型。callbackは必須、レスポンス取得時に呼ばれるコールバック関数、第1引数にHTTPステータス、第2引数にtokenオブジェクト。
+        //createToken(card, callback)：PAY.JPのサーバーと通信し、カード情報の認証を行い、トークンを作成。cardはObject型でカード情報を示している。number、exp_year、exp_monthが必須、cvcは任意でいずれもstr型。callbackは必須でレスポンス取得時に呼ばれるコールバック関数、第1引数にHTTPステータス、第2引数にtokenオブジェクト。
         if (status === 200) {
           $("#card_number").removeAttr("name");
           $("#cvc").removeAttr("name");
@@ -31,11 +31,11 @@ document.addEventListener('DOMContentLoaded', (e) => {
           //以上4つのデータを自サーバにpostしないようにparamsの値として含まれないようにする
           $("#card_token").append(
             $('<input type="hidden" name="payjp-token">').val(response.id)
-          ); //コントローラにトークンIDをparamsとして渡せるようにする。通信が成功し、statusが200になったとき、typeがhiddenとなっているinput要素が追加される。これが値として変数tokenを取得しているのでresponse.idがコントローラでparams[:payjp-token]として受け取ることが可能になる。
+          ); //Payjp.createTokenメソッドで返されたトークン情報がresponseであり、response.idというのはこのトークンオブジェクトのidを参照している。通信が成功し、statusが200になったとき、typeがhiddenとなっているトークンIDがコントローラに渡されるようになる。渡されたトークンIDはコントローラでparams[:payjp-token]として受け取ることが可能になる。
           document.CardForm.submit();
           alert("登録が完了しました");
         } else {
-          alert("登録失敗です。。");
+          alert("登録が失敗しました");
         }
       });
     });

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -24,8 +24,6 @@ document.addEventListener('DOMContentLoaded', (e) => {
       Payjp.createToken(card, (status, response) => {
         //createToken(card, callback)：PAY.JPのサーバーと通信し、カード情報の認証を行い、トークンを作成。cardは必須、Object型、カード情報であり、number exp_year exp_monthが必須、cvcは任意でいずれもstr型。callbackは必須、レスポンス取得時に呼ばれるコールバック関数、第1引数にHTTPステータス、第2引数にtokenオブジェクト。
         if (status === 200) {
-          // 出力（本来はサーバへ送信）
-          document.getElementById('card_token').innerHTML = response.card.id;
           $("#card_number").removeAttr("name");
           $("#cvc").removeAttr("name");
           $("#exp_month").removeAttr("name");

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,0 +1,36 @@
+//jsファイルで入力したカード情報を取得し、payjpのサーバーと通信を行い、トークンを取得する。
+//作成されたtokenはコントローラに送る。
+document.addEventListener(
+  "DOMContentLoaded", e => {
+    if (document.getElementById("token_submit") != null) { //token_submitというidがnullの場合、下記コードを実行しない
+      Payjp.setPublicKey('PAYJP_PUBLIC_KEY'); //認証のための公開鍵をセット。setPublicKey(key)：keyは必須でstr型。
+      var btn = document.getElementById("token_submit"); //IDがtoken_submitの場合に取得される
+      btn.addEventListener("click", e => {
+        e.preventDefault(); //clickを実行してページが更新されるのを防ぐ
+        var card = {
+          number: document.getElementById("card_number").value,
+          cvc: document.getElementById("cvc").value,
+          exp_month: document.getElementById("exp_month").value,
+          exp_year: document.getElementById("exp_year").value
+        }; //入力されたデータを取得
+        Payjp.createToken(card, (status, response) => {
+          //createToken(card[, options], callback)：PAY.JPのサーバーと通信し、カード情報の認証を行い、トークンを作成。cardは必須、Object型、カード情報であり、number exp_year exp_monthが必須、cvcは任意でいずれもstr型。optionsはテナントID指定関係で今回は不要。callbackは必須、レスポンス取得時に呼ばれるコールバック関数、第1引数にHTTPステータス、第2引数にtokenオブジェクト。
+          if (status === 200) { //成功した場合
+            $("#card_number").removeAttr("name");
+            $("#cvc").removeAttr("name");
+            $("#exp_month").removeAttr("name");
+            $("#exp_year").removeAttr("name"); //以上4つのデータを自サーバにpostしないようにparamsの値として含まれないようにする
+            $("#card_token").append(
+              $('<input type="hidden" name="payjp-token">').val(response.id)
+            ); //コントローラにトークンIDをparamsとして渡せるようにする。通信が成功し、statusが200になったとき、typeがhiddenとなっているinput要素が追加される。これが値として変数tokenを取得しているのでresponse.idがコントローラでparams[:payjp-token]として受け取ることが可能になる。
+            document.inputForm.submit();
+            alert("登録が完了しました"); //確認用
+          } else {
+            alert("カード情報が正しくありません。"); //確認用
+          }
+        });
+      });
+    }
+  },
+  false
+);

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -2,36 +2,44 @@
 
 // DOM読み込みが完了したら実行
 document.addEventListener('DOMContentLoaded', (e) => {
-  // payjp.jsの初期化、下記は公開鍵です。setPublicKey(key)：keyは必須でstr型。
-  Payjp.setPublicKey('pk_test_b55fd2a18b0c021513c245e1');
-  
-  // ボタンのイベントハンドリング
-  var btn = document.getElementById('token');
-  btn.addEventListener('click', (e) => {
-    e.preventDefault(); //clickを実行してページが更新されるのを防ぐ
+  //tokenというidがnullの場合、それ以下のコードを実行しない
+  if (document.getElementById("token") != null){
+    // payjp.jsの初期化、下記は公開鍵です。setPublicKey(key)：keyは必須でstr型。
+    Payjp.setPublicKey('pk_test_b55fd2a18b0c021513c245e1');
     
-    // 入力されたカード情報を取得
-    var card = {
-      number: document.getElementById('card_number').value,
-      cvc: document.getElementById('cvc').value,
-      exp_month: document.getElementById('exp_month').value,
-      exp_year: document.getElementById('exp_year').value
-    };
-    
-    // トークン生成
-    Payjp.createToken(card, (status, response) => {
-      //createToken(card, callback)：PAY.JPのサーバーと通信し、カード情報の認証を行い、トークンを作成。cardは必須、Object型、カード情報であり、number exp_year exp_monthが必須、cvcは任意でいずれもstr型。callbackは必須、レスポンス取得時に呼ばれるコールバック関数、第1引数にHTTPステータス、第2引数にtokenオブジェクト。
-      if (status === 200) {
-        // 出力（本来はサーバへ送信）
-        document.getElementById('card_token').innerHTML = response.card.id;
-      //   $("#card_token").append(
-      //     $('<input type="hidden" name="payjp-token">').val(response.id)
-      //   ); //コントローラにトークンIDをparamsとして渡せるようにする。通信が成功し、statusが200になったとき、typeがhiddenとなっているinput要素が追加される。これが値として変数tokenを取得しているのでresponse.idがコントローラでparams[:payjp-token]として受け取ることが可能になる。
-      //   document.InputForm.submit();
-      //   alert("登録が完了しました");
-      // } else {
-      //   alert("カード情報が正しくありませんよ");
-      }
+    // ボタンのイベントハンドリング
+    var btn = document.getElementById('token');
+    btn.addEventListener('click', (e) => {
+      e.preventDefault(); //clickを実行してページが更新されるのを防ぐ
+      
+      // 入力されたカード情報を取得
+      var card = {
+        number: document.getElementById('card_number').value,
+        cvc: document.getElementById('cvc').value,
+        exp_month: document.getElementById('exp_month').value,
+        exp_year: document.getElementById('exp_year').value
+      };
+      
+      // トークン生成
+      Payjp.createToken(card, (status, response) => {
+        //createToken(card, callback)：PAY.JPのサーバーと通信し、カード情報の認証を行い、トークンを作成。cardは必須、Object型、カード情報であり、number exp_year exp_monthが必須、cvcは任意でいずれもstr型。callbackは必須、レスポンス取得時に呼ばれるコールバック関数、第1引数にHTTPステータス、第2引数にtokenオブジェクト。
+        if (status === 200) {
+          // 出力（本来はサーバへ送信）
+          document.getElementById('card_token').innerHTML = response.card.id;
+          $("#card_number").removeAttr("name");
+          $("#cvc").removeAttr("name");
+          $("#exp_month").removeAttr("name");
+          $("#exp_year").removeAttr("name");
+          //以上4つのデータを自サーバにpostしないようにparamsの値として含まれないようにする
+          $("#card_token").append(
+            $('<input type="hidden" name="payjp-token">').val(response.id)
+          ); //コントローラにトークンIDをparamsとして渡せるようにする。通信が成功し、statusが200になったとき、typeがhiddenとなっているinput要素が追加される。これが値として変数tokenを取得しているのでresponse.idがコントローラでparams[:payjp-token]として受け取ることが可能になる。
+          document.CardForm.submit();
+          alert("登録が完了しました");
+        } else {
+          alert("登録失敗です。。");
+        }
+      });
     });
-  });
+  }
 }, false);

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -1,10 +1,53 @@
 class CreditCardsController < ApplicationController
+
+  require "payjp"
+
   def index
   end
 
-  def new
+  def new # カード情報の追加
+    card = Card.where(user_id: current_user.id) #Cardモデルからログイン中ユーザの情報を変数cardに入れる。
+    redirect_to action: "show" if card.exists? #すでにcardが存在していればshowアクションへ飛ぶ。
   end
 
-  def show
+  def create #payjpとCardのDBを作成
+    Payjp.api.key = ENV["PAYJP_PRIVATE_KEY"] #payjpと情報をやり取りするために秘密鍵をAPIキーに入れる。
+    if params['payjp-token'].blank?
+      redirect_to action: "new"
+    else
+      customer = Payjp::Customer.create(
+        description: '登録テストです。', #なくてもいいがわかりやすいので。
+        card: params['payjp-token'], #payjpでクレジットカードからトークンに変換されると、その情報はpayjp-tokenという名前でPOSTされる。
+        metadata: {user_id: current_user.id} #なくてもいいがわかりやすいので。単なる説明文みたいなものです。
+      )
+      @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card) #customer.idを自分たちのDBに保存することで、次回からカード情報を入力することなく、customer.idを指定して支払いできるようになる。default_cardはpayjpのレスポンスなので、ここでは定義していない。
+      if @card.save
+        redirect_to action: "show"
+      else
+        redirect_to action: "create"
+      end
+    end
+  end
+
+  def show #DBのカード情報をpayjpに送り、customer情報を取り出す。
+    card = Card.where(user_id: current_user.id).first #ログイン中ユーザの１番目のカードを取る。
+    if card.blank?
+      redirect_to action: "new" #カードがなければnewへ
+    else
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      customer = Payjp::Customer.retrieve(card.customer_id) #カードのcustomer情報をpayjpに送り、取り出した情報を変数customerに入れる。
+      @default_card_information = customer.cards.retrieve(card.card_id) #変数customerのカードのカードIDをデフォルトにする。default_card_informationはhamlで使います。
+    end
+  end
+
+  def delete #payjpとCardのDBを削除
+    card = Card.where(user_id: current_user.id).first
+    if card.present?
+      Payjp.api.key = ENV["PAYJP_PRIVATE_KEY"]
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      customer.delete
+      card.delete
+    end
+    redirect_to action: "new"
   end
 end

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -30,7 +30,7 @@ class CreditCardsController < ApplicationController
   end
 
   def show #DBのカード情報をpayjpに送り、customer情報を取り出す。
-    @card = Card.where(user_id: current_user.id).first #ログイン中ユーザの１番目のカードを取る。
+    @card = Card.find_by(user_id: current_user.id) #ログイン中ユーザの１番目のカードを取る。
     if @card.blank?
       redirect_to action: "new" #カードがなければnewへ
     else
@@ -41,7 +41,7 @@ class CreditCardsController < ApplicationController
   end
 
   def delete #payjpとCardのDBを削除
-    card = Card.where(user_id: current_user.id).first
+    card = Card.find_by(user_id: current_user.id)
     if card.present?
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
       customer = Payjp::Customer.retrieve(card.customer_id)

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -10,8 +10,8 @@ class CreditCardsController < ApplicationController
     redirect_to action: "show" if card.exists? #すでにcardが存在していればshowアクションへ飛ぶ。
   end
 
-  def create #payjpとCardのDBを作成
-    Payjp.api.key = ENV["PAYJP_PRIVATE_KEY"] #payjpと情報をやり取りするために秘密鍵をAPIキーに入れる。
+  def pay #payjpとCardのDBを作成
+    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"] #payjpと情報をやり取りするために秘密鍵をAPIキーに入れる。
     if params['payjp-token'].blank?
       redirect_to action: "new"
     else
@@ -24,7 +24,7 @@ class CreditCardsController < ApplicationController
       if @card.save
         redirect_to action: "show"
       else
-        redirect_to action: "create"
+        redirect_to action: "pay"
       end
     end
   end
@@ -43,7 +43,7 @@ class CreditCardsController < ApplicationController
   def delete #payjpとCardのDBを削除
     card = Card.where(user_id: current_user.id).first
     if card.present?
-      Payjp.api.key = ENV["PAYJP_PRIVATE_KEY"]
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
       customer = Payjp::Customer.retrieve(card.customer_id)
       customer.delete
       card.delete

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -15,12 +15,12 @@ class CreditCardsController < ApplicationController
     if params['payjp-token'].blank?
       redirect_to action: "new"
     else
-      customer = Payjp::Customer.create(
+      customer = Payjp::Customer.create( #Payjp::Customer.create：メールアドレスやIDなどを指定して顧客を作成するメソッド
         description: '登録テストです。', #なくてもいいがわかりやすいので。
         card: params['payjp-token'], #payjpでクレジットカードからトークンに変換されると、その情報はpayjp-tokenという名前でPOSTされる。
         metadata: {user_id: current_user.id} #なくてもいいがわかりやすいので。単なる説明文みたいなものです。
       )
-      @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card) #customer.idを自分たちのDBに保存することで、次回からカード情報を入力することなく、customer.idを指定して支払いできるようになる。default_cardはpayjpのレスポンスなので、ここでは定義していない。
+      @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card) #customer.idを自分たちのDBに保存することで、次回からカード情報を入力することなく、customer.idを指定して支払いできるようになる。default_cardはpayjpのレスポンスなので、ここでは定義していないが、payjpでは最初に情報入力したカードがdefault_cardになる。
       if @card.save
         redirect_to action: "show"
       else
@@ -35,7 +35,7 @@ class CreditCardsController < ApplicationController
       redirect_to action: "new" #カードがなければnewへ
     else
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-      customer = Payjp::Customer.retrieve(@card.customer_id) #カードのcustomer情報をpayjpに送り、取り出した情報を変数customerに入れる。
+      customer = Payjp::Customer.retrieve(@card.customer_id) #カードのcustomer情報をpayjpに送り、取り出した情報を変数customerに入れる。 Payjp::Customer.retrieve()：引数に指定したidで顧客情報を取得するメソッド。
       @default_card_information = customer.cards.retrieve(@card.card_id) #変数customerのカードのカードIDをデフォルトにする。default_card_informationはhamlで使います。
     end
   end

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -30,13 +30,13 @@ class CreditCardsController < ApplicationController
   end
 
   def show #DBのカード情報をpayjpに送り、customer情報を取り出す。
-    card = Card.where(user_id: current_user.id).first #ログイン中ユーザの１番目のカードを取る。
-    if card.blank?
+    @card = Card.where(user_id: current_user.id).first #ログイン中ユーザの１番目のカードを取る。
+    if @card.blank?
       redirect_to action: "new" #カードがなければnewへ
     else
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-      customer = Payjp::Customer.retrieve(card.customer_id) #カードのcustomer情報をpayjpに送り、取り出した情報を変数customerに入れる。
-      @default_card_information = customer.cards.retrieve(card.card_id) #変数customerのカードのカードIDをデフォルトにする。default_card_informationはhamlで使います。
+      customer = Payjp::Customer.retrieve(@card.customer_id) #カードのcustomer情報をpayjpに送り、取り出した情報を変数customerに入れる。
+      @default_card_information = customer.cards.retrieve(@card.card_id) #変数customerのカードのカードIDをデフォルトにする。default_card_informationはhamlで使います。
     end
   end
 

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -6,8 +6,8 @@ class CreditCardsController < ApplicationController
   end
 
   def new # カード情報の追加
-    card = Card.where(user_id: current_user.id) #Cardモデルからログイン中ユーザの情報を変数cardに入れる。
-    redirect_to action: "show" if card.exists? #すでにcardが存在していればshowアクションへ飛ぶ。
+    cards = Card.where(user_id: current_user.id) #Cardモデルからログイン中ユーザの情報を変数cardに入れる。
+    redirect_to action: "show" if cards.exists? #すでにcardが存在していればshowアクションへ飛ぶ。
   end
 
   def pay #payjpとCardのDBを作成

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,8 +1,9 @@
 class Card < ApplicationRecord
   belongs_to :user, optional: true
 
-  validates :number, presence: true, format: {with: /\A\d{14}\z|\A\d{15}\z|\A\d{16}\z/}
-  validates  :validated_date_year, presence: true, format: {with: /\A\d{2}\z/}
-  validates  :validated_date_month, presence: true, format: {with: /\b[1-9]\b|\A1[0-2]\Z/}
-  validates  :security_number, presence: true, format: {with: /\A\d{3}\z|\A\d{4}\z/}
+  # サインアップ時のテストであるが、使用する可能性があるため一時的にコメントアウトしている。
+  # validates :number, presence: true, format: {with: /\A\d{14}\z|\A\d{15}\z|\A\d{16}\z/}
+  # validates  :validated_date_year, presence: true, format: {with: /\A\d{2}\z/}
+  # validates  :validated_date_month, presence: true, format: {with: /\b[1-9]\b|\A1[0-2]\Z/}
+  # validates  :security_number, presence: true, format: {with: /\A\d{3}\z|\A\d{4}\z/}
 end

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -6,7 +6,7 @@
     = render 'myinfomations/sidebar'
   .new
     .new__card
-      = form_with url:root_path do |f|
+      = form_with url:new_credit_card_path, method: :post, id: 'charge-form', name: "InputForm", local: true do |f|
         
         .new__card__header
           %h1
@@ -20,7 +20,7 @@
               %span
                 必須
               .new__card__create__formgroup__number__form
-                = f.text_field :text, class:"new__card__create__formgroup__number__form__text", placeholder: "半角数字のみ",maxlength: "16"
+                = f.text_field :text, class:"new__card__create__formgroup__number__form__text", placeholder: "半角数字のみ",maxlength: "16", id: "card_number"
               .new__card__create__formgroup__number__image
                 %li
                   = image_tag("https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Logo_Visa.svg/2000px-Logo_Visa.svg.png", alt: "visa", size: '45x17')
@@ -44,7 +44,7 @@
                 必須
               .new__card__create__formgroup__validatedDate__select
                 .new__card__create__formgroup__validatedDate__select__month
-                  %select.new__card__create__formgroup__validatedDate__select__month__box
+                  %select.new__card__create__formgroup__validatedDate__select__month__box{name: "exp_month", type: "text", id: "exp_month"}
                     %option{value: "1"} 01
                     %option{value: "2"} 02
                     %option{value: "3"} 03
@@ -60,7 +60,7 @@
                   %label
                     月
                 .new__card__create__formgroup__validatedDate__select__year
-                  %select.new__card__create__formgroup__validatedDate__select__year__box
+                  %select.new__card__create__formgroup__validatedDate__select__year__box{name: "exp_year", type: "text", id: "exp_year"}
                     %option{value: "2020"} 20
                     %option{value: "2021"} 21
                     %option{value: "2022"} 22
@@ -78,14 +78,13 @@
               %span
                 必須
               .new__card__create__formgroup__securityNumber__form
-                = f.text_field :text, class:"new__card__create__formgroup__securityNumber__form__text", placeholder: "カード背面4桁もしくは3桁の番号",maxlength: "4"
+                = f.text_field :text, class:"new__card__create__formgroup__securityNumber__form__text", placeholder: "カード背面4桁もしくは3桁の番号", maxlength: "4", id: "cvc"
             
               .new__card__create__formgroup__securityNumber__question
                 = icon('fas', 'question-circle',class:"new__card__create__formgroup__securityNumber__question--icon")
                 カード裏面の番号とは？
-
             .new__card__create__formgroup__add
-              = link_to "#", class: "new__card__create__formgroup__add__btn" do
+              = link_to "#", class: "new__card__create__formgroup__add__btn", id: "token_submit" do
                 追加する
 
 .footer

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -87,6 +87,8 @@
               .new__card__create__formgroup__add
                 = submit_tag "追加する", id: "token", class: "new__card__create__formgroup__add__btn"
 
+            #card_token
+
 .footer
   = render 'items/footer'
 

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -6,7 +6,8 @@
     = render 'myinfomations/sidebar'
   .new
     .new__card
-      = form_with url:root_path do |f|
+      -# = form_with url:pay_credit_cards_path, method: :post, id: 'charge-form', name: "CardForm", local: true do |f|
+      = form_tag(pay_credit_cards_path, method: :post, id: 'charge-form', name: "CardForm") do
         
         .new__card__header
           %h1
@@ -20,7 +21,8 @@
               %span
                 必須
               .new__card__create__formgroup__number__form
-                = f.text_field :text, class:"new__card__create__formgroup__number__form__text", placeholder: "半角数字のみ",maxlength: "16", id: "card_number"
+                -# = f.text_field :text, class:"new__card__create__formgroup__number__form__text", placeholder: "半角数字のみ",maxlength: "16", id: "card_number", name: "number"
+                = text_field_tag "number", "", class:"new__card__create__formgroup__number__form__text", placeholder: "半角数字のみ",maxlength: "16", id: "card_number"
               .new__card__create__formgroup__number__image
                 %li
                   = image_tag("https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Logo_Visa.svg/2000px-Logo_Visa.svg.png", alt: "visa", size: '45x17')
@@ -44,7 +46,7 @@
                 必須
               .new__card__create__formgroup__validatedDate__select
                 .new__card__create__formgroup__validatedDate__select__month
-                  %select.new__card__create__formgroup__validatedDate__select__month__box{id: "exp_month", type: "text"}
+                  %select.new__card__create__formgroup__validatedDate__select__month__box{id: "exp_month", name: "exp_month", type: "text"}
                     %option{value: "1"} 01
                     %option{value: "2"} 02
                     %option{value: "3"} 03
@@ -60,7 +62,7 @@
                   %label
                     月
                 .new__card__create__formgroup__validatedDate__select__year
-                  %select.new__card__create__formgroup__validatedDate__select__year__box{id: "exp_year", type: "text"}
+                  %select.new__card__create__formgroup__validatedDate__select__year__box{id: "exp_year", name: "exp_year", type: "text"}
                     %option{value: "2020"} 20
                     %option{value: "2021"} 21
                     %option{value: "2022"} 22
@@ -78,15 +80,18 @@
               %span
                 必須
               .new__card__create__formgroup__securityNumber__form
-                = f.text_field :text, class:"new__card__create__formgroup__securityNumber__form__text", placeholder: "カード背面4桁もしくは3桁の番号",maxlength: "4", id: "cvc"
+                -# = f.text_field :text, class:"new__card__create__formgroup__securityNumber__form__text", placeholder: "カード背面4桁もしくは3桁の番号",maxlength: "4", id: "cvc", name: "cvc"
+                = text_field_tag "cvc", "", class:"new__card__create__formgroup__securityNumber__form__text", placeholder: "カード背面4桁もしくは3桁の番号",maxlength: "4", id: "cvc"
             
               .new__card__create__formgroup__securityNumber__question
                 = icon('fas', 'question-circle',class:"new__card__create__formgroup__securityNumber__question--icon")
                 カード裏面の番号とは？
+              
+              .new__card__create__formgroup__add
+                = submit_tag "追加する", id: "token", class: "new__card__create__formgroup__add__btn"
 
-            .new__card__create__formgroup__add
-              = link_to "#", class: "new__card__create__formgroup__add__btn", id: "token" do
-                追加する
+            -# .actions
+            -#   = f.submit "追加する", class: "new__card__create__formgroup__add new__card__create__formgroup__add__btn", id: "token"
             生成されたトークン：
             #card_token
 

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -6,7 +6,7 @@
     = render 'myinfomations/sidebar'
   .new
     .new__card
-      = form_with url:new_credit_card_path, method: :post, id: 'charge-form', name: "InputForm", local: true do |f|
+      = form_with url:root_path do |f|
         
         .new__card__header
           %h1
@@ -44,7 +44,7 @@
                 必須
               .new__card__create__formgroup__validatedDate__select
                 .new__card__create__formgroup__validatedDate__select__month
-                  %select.new__card__create__formgroup__validatedDate__select__month__box{name: "exp_month", type: "text", id: "exp_month"}
+                  %select.new__card__create__formgroup__validatedDate__select__month__box{id: "exp_month", type: "text"}
                     %option{value: "1"} 01
                     %option{value: "2"} 02
                     %option{value: "3"} 03
@@ -60,7 +60,7 @@
                   %label
                     月
                 .new__card__create__formgroup__validatedDate__select__year
-                  %select.new__card__create__formgroup__validatedDate__select__year__box{name: "exp_year", type: "text", id: "exp_year"}
+                  %select.new__card__create__formgroup__validatedDate__select__year__box{id: "exp_year", type: "text"}
                     %option{value: "2020"} 20
                     %option{value: "2021"} 21
                     %option{value: "2022"} 22
@@ -78,14 +78,17 @@
               %span
                 必須
               .new__card__create__formgroup__securityNumber__form
-                = f.text_field :text, class:"new__card__create__formgroup__securityNumber__form__text", placeholder: "カード背面4桁もしくは3桁の番号", maxlength: "4", id: "cvc"
+                = f.text_field :text, class:"new__card__create__formgroup__securityNumber__form__text", placeholder: "カード背面4桁もしくは3桁の番号",maxlength: "4", id: "cvc"
             
               .new__card__create__formgroup__securityNumber__question
                 = icon('fas', 'question-circle',class:"new__card__create__formgroup__securityNumber__question--icon")
                 カード裏面の番号とは？
+
             .new__card__create__formgroup__add
-              = link_to "#", class: "new__card__create__formgroup__add__btn", id: "token_submit" do
+              = link_to "#", class: "new__card__create__formgroup__add__btn", id: "token" do
                 追加する
+            生成されたトークン：
+            #card_token
 
 .footer
   = render 'items/footer'

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -6,7 +6,6 @@
     = render 'myinfomations/sidebar'
   .new
     .new__card
-      -# = form_with url:pay_credit_cards_path, method: :post, id: 'charge-form', name: "CardForm", local: true do |f|
       = form_tag(pay_credit_cards_path, method: :post, id: 'charge-form', name: "CardForm") do
         
         .new__card__header
@@ -21,7 +20,6 @@
               %span
                 必須
               .new__card__create__formgroup__number__form
-                -# = f.text_field :text, class:"new__card__create__formgroup__number__form__text", placeholder: "半角数字のみ",maxlength: "16", id: "card_number", name: "number"
                 = text_field_tag "number", "", class:"new__card__create__formgroup__number__form__text", placeholder: "半角数字のみ",maxlength: "16", id: "card_number"
               .new__card__create__formgroup__number__image
                 %li
@@ -80,7 +78,6 @@
               %span
                 必須
               .new__card__create__formgroup__securityNumber__form
-                -# = f.text_field :text, class:"new__card__create__formgroup__securityNumber__form__text", placeholder: "カード背面4桁もしくは3桁の番号",maxlength: "4", id: "cvc", name: "cvc"
                 = text_field_tag "cvc", "", class:"new__card__create__formgroup__securityNumber__form__text", placeholder: "カード背面4桁もしくは3桁の番号",maxlength: "4", id: "cvc"
             
               .new__card__create__formgroup__securityNumber__question

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -90,11 +90,6 @@
               .new__card__create__formgroup__add
                 = submit_tag "追加する", id: "token", class: "new__card__create__formgroup__add__btn"
 
-            -# .actions
-            -#   = f.submit "追加する", class: "new__card__create__formgroup__add new__card__create__formgroup__add__btn", id: "token"
-            生成されたトークン：
-            #card_token
-
 .footer
   = render 'items/footer'
 

--- a/app/views/credit_cards/show.html.haml
+++ b/app/views/credit_cards/show.html.haml
@@ -33,8 +33,9 @@
                 = exp_month + " / " + exp_year
           
             .card__content__list__register__delete
-              = link_to "delete_credit_cards_path", class: "card__content__list__register__delete__btn", method: :post, id: 'charge-form', name: "CardForm" do
-                削除する
+              = form_tag(delete_credit_cards_path, method: :post, id: 'charge-form',  name: "CardForm") do
+                %input{ type: "hidden", name: "card_id", value: "" }
+                %button{class: "card__content__list__register__delete__btn"} 削除する
 
         .card__content__method
           = link_to "#", class: "card__content__method__btn" do

--- a/app/views/credit_cards/show.html.haml
+++ b/app/views/credit_cards/show.html.haml
@@ -24,14 +24,16 @@
           
             .card__content__list__register__number
               %li
-                ************2002
+                = "**** **** ****" + @default_card_information.last4
           
             .card__content__list__register__validatedDate
               %li
-                03/21
+                - exp_month = @default_card_information.exp_month.to_s
+                - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+                = exp_month + " / " + exp_year
           
             .card__content__list__register__delete
-              = link_to "#", class: "card__content__list__register__delete__btn" do
+              = link_to "card_delete_path", class: "card__content__list__register__delete__btn", method: :post, id: 'charge-form', name: "InputForm" do
                 削除する
 
         .card__content__method

--- a/app/views/credit_cards/show.html.haml
+++ b/app/views/credit_cards/show.html.haml
@@ -33,7 +33,7 @@
                 = exp_month + " / " + exp_year
           
             .card__content__list__register__delete
-              = link_to "card_delete_path", class: "card__content__list__register__delete__btn", method: :post, id: 'charge-form', name: "InputForm" do
+              = link_to "delete_credit_cards_path", class: "card__content__list__register__delete__btn", method: :post, id: 'charge-form', name: "CardForm" do
                 削除する
 
         .card__content__method

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,6 +4,7 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title Mercari
     %link{crossorigin: "anonymous", href: "https://use.fontawesome.com/releases/v5.1.0/css/all.css", integrity: "sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt", rel: "stylesheet"}/
+    %script{src: "https://js.pay.jp/", type: "text/javascript"}
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,13 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :show]
   resources :categorized_items, only: [:index]
   resources :branded_items, only: [:index]
-  resources :credit_cards, only: [:index,:new,:show]
+  resources :credit_cards, only: [:index,:new,:show] do
+    collection do
+      post 'show', to: 'credit_cards#show'
+      post 'create', to: 'credit_cards#create'
+      post 'delete', to: 'credit_cards#delete'
+    end
+  end
   resources :create_accounts, only: [:index]
   resources :myinfomations, only: [:index]
   resources :notifications, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   resources :credit_cards, only: [:index,:new,:show] do
     collection do
       post 'show', to: 'credit_cards#show'
-      post 'create', to: 'credit_cards#create'
+      post 'pay', to: 'credit_cards#pay'
       post 'delete', to: 'credit_cards#delete'
     end
   end

--- a/db/migrate/20200229092718_add_customer_id_and_card_id_to_cards.rb
+++ b/db/migrate/20200229092718_add_customer_id_and_card_id_to_cards.rb
@@ -1,0 +1,6 @@
+class AddCustomerIdAndCardIdToCards < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cards, :customer_id, :string
+    add_column :cards, :card_id, :string
+  end
+end

--- a/db/migrate/20200303140217_remove_user_id_from_cards.rb
+++ b/db/migrate/20200303140217_remove_user_id_from_cards.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromCards < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :cards, :user_id, :references
+  end
+end

--- a/db/migrate/20200303140444_add_column_to_cards.rb
+++ b/db/migrate/20200303140444_add_column_to_cards.rb
@@ -1,0 +1,5 @@
+class AddColumnToCards < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cards, :user_id, :integer
+  end
+end

--- a/db/migrate/20200303151146_remove_contents_from_cards.rb
+++ b/db/migrate/20200303151146_remove_contents_from_cards.rb
@@ -1,0 +1,8 @@
+class RemoveContentsFromCards < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :cards, :number, :integer
+    remove_column :cards, :validated_date_year, :integer
+    remove_column :cards, :validated_date_month, :integer
+    remove_column :cards, :security_number, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_03_140444) do
+ActiveRecord::Schema.define(version: 2020_03_03_151146) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "zip_code", null: false
@@ -32,10 +32,6 @@ ActiveRecord::Schema.define(version: 2020_03_03_140444) do
   end
 
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "number", null: false
-    t.integer "validated_date_year", null: false
-    t.integer "validated_date_month", null: false
-    t.integer "security_number", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "customer_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_29_092718) do
+ActiveRecord::Schema.define(version: 2020_03_03_140444) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "zip_code", null: false
@@ -36,12 +36,11 @@ ActiveRecord::Schema.define(version: 2020_02_29_092718) do
     t.integer "validated_date_year", null: false
     t.integer "validated_date_month", null: false
     t.integer "security_number", null: false
-    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "customer_id"
     t.string "card_id"
-    t.index ["user_id"], name: "index_cards_on_user_id"
+    t.integer "user_id"
   end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -120,7 +119,6 @@ ActiveRecord::Schema.define(version: 2020_02_29_092718) do
   end
 
   add_foreign_key "addresses", "users"
-  add_foreign_key "cards", "users"
   add_foreign_key "cellphones", "users"
   add_foreign_key "images", "items"
   add_foreign_key "items", "brands"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_18_100018) do
+ActiveRecord::Schema.define(version: 2020_02_29_092718) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "zip_code", null: false
@@ -39,6 +39,8 @@ ActiveRecord::Schema.define(version: 2020_02_18_100018) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "customer_id"
+    t.string "card_id"
     t.index ["user_id"], name: "index_cards_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -93,27 +93,6 @@ Address.create(
   ]
 )
 
-#クレジッド
-# Card.create(
-#   [
-#     #ユーザー１
-#     {
-#       number:               1234567890123456,
-#       validated_date_year:  22,
-#       validated_date_month: 10,
-#       security_number:      111,
-#       user_id:              1,
-#     },
-#     #ユーザー2
-#     {
-#       number:               1111111111111111,
-#       validated_date_year:  24,
-#       validated_date_month: 2,
-#       security_number:      222,
-#       user_id:              2,
-#     }
-#   ]
-# )
 c1 = Category.create(name:"レディース")
 
 c1_1 = c1.children.create(name: "トップス")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -94,26 +94,26 @@ Address.create(
 )
 
 #クレジッド
-Card.create(
-  [
-    #ユーザー１
-    {
-      number:               1234567890123456,
-      validated_date_year:  22,
-      validated_date_month: 10,
-      security_number:      111,
-      user_id:              1,
-    },
-    #ユーザー2
-    {
-      number:               1111111111111111,
-      validated_date_year:  24,
-      validated_date_month: 2,
-      security_number:      222,
-      user_id:              2,
-    }
-  ]
-)
+# Card.create(
+#   [
+#     #ユーザー１
+#     {
+#       number:               1234567890123456,
+#       validated_date_year:  22,
+#       validated_date_month: 10,
+#       security_number:      111,
+#       user_id:              1,
+#     },
+#     #ユーザー2
+#     {
+#       number:               1111111111111111,
+#       validated_date_year:  24,
+#       validated_date_month: 2,
+#       security_number:      222,
+#       user_id:              2,
+#     }
+#   ]
+# )
 c1 = Category.create(name:"レディース")
 
 c1_1 = c1.children.create(name: "トップス")


### PR DESCRIPTION
# What
クレジットカード決済による購入機能の実装にあたり、まず初めにクレジットカード決済代行サービスpay.jp(Comments参照)を使ったクレジットカード情報の登録・削除の機能を実装。
DB上でカード情報(customer_idとcard_id)が入力・削除されるかを確認していただきたい。
※内容をわかりやすくするため、説明書きのコメントアウトをあえて載せているところがあります。
※カード番号・有効期限・CVCは本来DBに載ってはいけない情報であり、pay.jpに預けています。その代わそれらと紐づけられているcustomer_idとcard_idでサーバーとやり取りをする仕組みです。

# Why
一気に購入機能まで実装すると内容が煩雑になるため、第１段階としてクレジットカード情報をpay.jpに登録し、顧客ID(`customer_id`)、カードID(`card_id`)を受け取る流れまでの実装を行ったので、ここまでの確認をお願いしたい。
(顧客IDとカードIDはトークン(Comments参照)ともちろん紐づけられており、これらのIDを使い、サーバーとやり取りを行う。)

# How
slackで送信した秘密鍵を`bash_profile`(シェルがzshなら`zprofile`)に追記して、`source ~/.bash_profile` (か、 `source ~/.zprofile`)をしてください。
その後、pullしたら`rails db:migrate:reset` -> `rails db:seed` し(DB上のカード情報を消すため。)、
`rails s`したら、ログインし(email: aaa@aaa, PW: abcd123)、
[/credit_cards/new](http://localhost:3000/credit_cards/new)
に行き、以下のクレジットカード情報を入力してください。

> カード番号：4242424242424242 (←pay.jpが推奨しているテストカード用の番号なので必ずこれを使ってください。)
> 有効期限：今より未来ならなんでも良い
> セキュリティコード：３桁ならなんでも良い

以下動画のように入力情報が表示されていれば登録完了。
(ブラウザの表示)
https://gyazo.com/c11184de70651adcda7f5b2929b17076
(DBの表示)
https://gyazo.com/6b3eb797a662d65b74fd8a8b658fdde8
※参考までにpay.jpでの表示は以下動画のようになっている。
customer_idが顧客IDと、card_idがカードIDと一致し、入力したカード情報(番号下４桁と有効期限)が反映されていることがわかる。
https://gyazo.com/240dbe69fa619c6c519e786b4fe41499

また、クレジットカード情報の削除も以下動画のように行える。pay.jpとDBから情報が消えていることを確認。
https://gyazo.com/74050f2c650ab3a74a728f3773cd29a4
https://gyazo.com/0a8fb0bb79926f341193fb71478e7b65

Pay.jpのところは私しか見れないので、メンバーの皆様には上記動画のようにDB上で入力・削除されたかを確認していただきたい。

※動画中の顧客のIDリストは私が適当に入れたものであり、情報漏洩ではありませんのでご安心ください。

# Comments
今回活用するクレジットカード決済代行サービスpay.jpについて説明する。
Pay.jpではクレジットカード番号をいったんトークン化し、そのトークンを使い決済処理を行う。通常、このトークンは一時的にしか使えない有効期限付のものであるが、顧客と紐付けを行うことで繰り返し使えるようになる。
このトークンの仕組みでは、クレジットカード番号自体、事業主(ここでいう我々)側で触れないようにする(詳細は[こちら](http://payjp-announce.hatenablog.com/entry/2017/11/10/182738)) JavaScriptの仕組みが用意されており、トークンだけがサーバーに送信されるようになっている。シーケンス図にすると以下のようになる。
![image](https://user-images.githubusercontent.com/58387687/75806032-49b92680-5dc6-11ea-9c8d-bd2557373fab.png)
(出典：https://payjp.hatenablog.com/)

# Reference
下記リンクがとても参考になりました。
＜PAY.JP APIガイド：カード情報のトークン化＞ https://pay.jp/docs/cardtoken
＜Qiita：Payjpでクレジットカード登録と削除機能を実装する(Rails)＞ https://qiita.com/takachan_coding/items/f7e70794b9ca03b559dd