### PR TITLE
credit_cards登録・削除画面でのform_tag -> form_with書き換えによる変更

### DIFF
--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -1,17 +1,14 @@
 .header
   = render 'items/header'
-
 .main
   .sidebar
     = render 'myinfomations/sidebar'
   .new
     .new__card
-      = form_tag(pay_credit_cards_path, method: :post, id: 'charge-form', name: "CardForm") do
-        
+      = form_with url:pay_credit_cards_path, method: :post, html: { name: "CardForm" }, local:true do |f|
         .new__card__header
           %h1
             クレジットカード情報入力
-
         .new__card__create
           .new__card__create__formgroup
             .new__card__create__formgroup__number
@@ -20,7 +17,7 @@
               %span
                 必須
               .new__card__create__formgroup__number__form
-                = text_field_tag "number", "", class:"new__card__create__formgroup__number__form__text", placeholder: "半角数字のみ",maxlength: "16", id: "card_number"
+                = f.text_field "number", class:"new__card__create__formgroup__number__form__text", placeholder: "半角数字のみ",maxlength: "16", id: "card_number"
               .new__card__create__formgroup__number__image
                 %li
                   = image_tag("https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Logo_Visa.svg/2000px-Logo_Visa.svg.png", alt: "visa", size: '45x17')
@@ -36,7 +33,6 @@
                   = image_tag("https://clipartart.com/images/diners-club-logo-clipart.png", alt: "dinersclub", size: '25x20')
                 %li
                   = image_tag("https://blog.mudora.jp/wp-content/uploads/2013/11/disc_5121.png", alt: "discover", size: '30x25')
-
             .new__card__create__formgroup__validatedDate
               %label
                 有効期限
@@ -78,20 +74,15 @@
               %span
                 必須
               .new__card__create__formgroup__securityNumber__form
-                = text_field_tag "cvc", "", class:"new__card__create__formgroup__securityNumber__form__text", placeholder: "カード背面4桁もしくは3桁の番号",maxlength: "4", id: "cvc"
-            
+                = f.text_field "cvc", class:"new__card__create__formgroup__securityNumber__form__text", placeholder: "カード背面4桁もしくは3桁の番号",maxlength: "4", id: "cvc"
               .new__card__create__formgroup__securityNumber__question
                 = icon('fas', 'question-circle',class:"new__card__create__formgroup__securityNumber__question--icon")
                 カード裏面の番号とは？
-              
               .new__card__create__formgroup__add
-                = submit_tag "追加する", id: "token", class: "new__card__create__formgroup__add__btn"
-
+                = f.submit "追加する", id: "token", class: "new__card__create__formgroup__add__btn", name: "CardForm"
             #card_token
-
 .footer
   = render 'items/footer'
-
 .exhibition
   =link_to new_product_path, class: "exhibition__link" do
     出品

--- a/app/views/credit_cards/show.html.haml
+++ b/app/views/credit_cards/show.html.haml
@@ -33,7 +33,7 @@
                 = exp_month + " / " + exp_year
           
             .card__content__list__register__delete
-              = form_tag(delete_credit_cards_path, method: :post, id: 'charge-form',  name: "CardForm") do
+              = form_with url:delete_credit_cards_path, method: :post, html: { name: "CardForm" }, local:true do |f|
                 %input{ type: "hidden", name: "card_id", value: "" }
                 %button{class: "card__content__list__register__delete__btn"} 削除する
 


### PR DESCRIPTION
# What
タイトルの通り。

# Why
PR#70ではform_tagにしていたが、form_withへの書き換えがうまくいったので、問題ないか確認いただきたい。
PR#70はこちら-> #70 
本書き換えをして、#70で示した動作ができたことを確認済。