### PR TITLE
(購入者側の)商品詳細画面から購入確認画面への遷移と購入処理の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,6 +41,10 @@ class ItemsController < ApplicationController
     @brand = Brand.find(@item.brand_id)
     @categorys = Category.find(@item.category_id)
     @subitems = Item.where.not(id: params[:id]).where(category_id: @categorys).where(brand_id: @brand, transaction_status: 1).last(6).reverse
+    if current_user.id != @item.saler_user_id && @item.transaction_status == 1
+    else
+      redirect_to root_path
+    end
   end
 
   def edit

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,7 +41,7 @@ class ItemsController < ApplicationController
     @brand = Brand.find(@item.brand_id)
     @categorys = Category.find(@item.category_id)
     @subitems = Item.where.not(id: params[:id]).where(category_id: @categorys).where(brand_id: @brand, transaction_status: 1).last(6).reverse
-    if current_user.id != @item.saler_user_id && @item.transaction_status == 1
+    if user_signed_in? && user_logcurrent_user.id != @item.saler_user_id && @item.transaction_status == 1
     else
       redirect_to root_path
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,10 +41,6 @@ class ItemsController < ApplicationController
     @brand = Brand.find(@item.brand_id)
     @categorys = Category.find(@item.category_id)
     @subitems = Item.where.not(id: params[:id]).where(category_id: @categorys).where(brand_id: @brand, transaction_status: 1).last(6).reverse
-    if user_signed_in? && user_logcurrent_user.id != @item.saler_user_id && @item.transaction_status == 1
-    else
-      redirect_to root_path
-    end
   end
 
   def edit

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -31,17 +31,20 @@ class OrdersController < ApplicationController
       customer: @card.customer_id, #顧客ID
       currency: 'jpy' #日本円
     )
-    @item.update(transaction_status: 2) #購入済ステータスにupdate
     @item.update(buyer_user_id: current_user.id) #購入者のIDを保存
-    redirect_to ({action: 'done', id: @item.id})  #購入完了画面に遷移
+    unless user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
+      redirect_to ({action: 'done', id: @item.id})  #購入完了画面に遷移
+    else
+    end
+    @item.update(transaction_status: 2) #購入済ステータスにupdate
   end
 
   def done
     @item = Item.find(params[:id])
-    if user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
-    else
-      redirect_to root_path
-    end
+    # if user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
+    # else
+    #   redirect_to root_path
+    # end
   end
 
   private

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -32,12 +32,13 @@ class OrdersController < ApplicationController
       currency: 'jpy' #日本円
     )
     @item.update(transaction_status: 2) #購入済ステータスにupdate
+    @item.update(buyer_user_id: current_user.id) #購入者のIDを保存
     redirect_to ({action: 'done', id: @item.id})  #購入完了画面に遷移
   end
 
   def done
     @item = Item.find(params[:id])
-    if current_user.id != @item.saler_user_id && @item.transaction_status == 2
+    if current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
     else
       redirect_to root_path
     end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -15,24 +15,9 @@ class OrdersController < ApplicationController
     @address = current_user.address
   end
 
-  # def create
-  # end
-
-  # def edit
-  # end
-
-  # def update
-  # end
-
   def pay
-    # Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-    # Payjp::Charge.create(
-    #   amount: @item.price, #支払い金額
-    #   customer: @card.customer_id, #顧客ID
-    #   currency: 'jpy' #日本円
-    # )
     @item.update(buyer_user_id: current_user.id) #購入者のIDを保存
-    unless user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
+    unless user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status != 1 && request.referer&.include?("/orders/#{@item.id}/new")
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
       Payjp::Charge.create(
         amount: @item.price, #支払い金額
@@ -47,7 +32,7 @@ class OrdersController < ApplicationController
 
   def done
     @item = Item.find(params[:id])
-    unless user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
+    unless user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status != 1 && request.referer&.include?("/orders/#{@item.id}/new")
       redirect_to root_path
     else
     end
@@ -63,13 +48,5 @@ class OrdersController < ApplicationController
       redirect_to root_path
     end
   end
-
-  # def set_item
-  #   @item = Item.find(params[:id])
-  #   if current_user.id == @item.saler_user_id && @item.transaction_status == 1
-  #   else
-  #     redirect_to root_path
-  #   end
-  # end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -38,7 +38,7 @@ class OrdersController < ApplicationController
 
   def done
     @item = Item.find(params[:id])
-    if current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
+    if user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
     else
       redirect_to root_path
     end
@@ -48,7 +48,7 @@ class OrdersController < ApplicationController
 
   def set_card
     @item = Item.find(params[:id])
-    if current_user.id != @item.saler_user_id && @item.transaction_status == 1
+    if user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 1
       @card = Card.find_by(user_id: current_user.id) #credit_cards_controllerで使用したCardテーブルからpayjpの顧客IDを検索
     else
       redirect_to root_path

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -25,7 +25,6 @@ class OrdersController < ApplicationController
         currency: 'jpy' #日本円
       )
       redirect_to ({action: 'done', id: @item.id})  #購入完了画面に遷移
-    else
     end
     @item.update(transaction_status: 2) #購入済ステータスにupdate
   end
@@ -34,7 +33,6 @@ class OrdersController < ApplicationController
     @item = Item.find(params[:id])
     unless user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
       redirect_to root_path
-    else
     end
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,7 +2,6 @@ class OrdersController < ApplicationController
 
   require 'payjp'
   before_action :set_card, only: [:new, :pay]
-  before_action :set_item, only: [:new, :pay, :done]
 
   def new
     if @card.blank?
@@ -32,29 +31,34 @@ class OrdersController < ApplicationController
       customer: @card.customer_id, #顧客ID
       currency: 'jpy' #日本円
     )
+    @item.update(transaction_status: 2) #購入済ステータスにupdate
     redirect_to ({action: 'done', id: @item.id})  #購入完了画面に遷移
   end
 
   def done
+    @item = Item.find(params[:id])
+    if current_user.id != @item.saler_user_id && @item.transaction_status == 2
+    else
+    end
   end
 
   private
 
   def set_card
     @item = Item.find(params[:id])
-    if current_user.id == @item.saler_user_id && @item.transaction_status == 1
+    if current_user.id != @item.saler_user_id && @item.transaction_status == 1
       @card = Card.find_by(user_id: current_user.id) #credit_cards_controllerで使用したCardテーブルからpayjpの顧客IDを検索
     else
       redirect_to root_path
     end
   end
 
-  def set_item
-    @item = Item.find(params[:id])
-    if current_user.id == @item.saler_user_id && @item.transaction_status == 1
-    else
-      redirect_to root_path
-    end
-  end
+  # def set_item
+  #   @item = Item.find(params[:id])
+  #   if current_user.id == @item.saler_user_id && @item.transaction_status == 1
+  #   else
+  #     redirect_to root_path
+  #   end
+  # end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -16,7 +16,6 @@ class OrdersController < ApplicationController
   end
 
   def pay
-    @item.update(buyer_user_id: current_user.id) #購入者のIDを保存
     unless user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status != 1 && request.referer&.include?("/orders/#{@item.id}/new")
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
       Payjp::Charge.create(
@@ -26,7 +25,7 @@ class OrdersController < ApplicationController
       )
       redirect_to ({action: 'done', id: @item.id})  #購入完了画面に遷移
     end
-    @item.update(transaction_status: 2) #購入済ステータスにupdate
+    @item.update(buyer_user_id: current_user.id, transaction_status: 2) #購入者のIDを保存と、購入済ステータスにupdate
   end
 
   def done

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -15,14 +15,14 @@ class OrdersController < ApplicationController
     @address = current_user.address
   end
 
-  def create
-  end
+  # def create
+  # end
 
-  def edit
-  end
+  # def edit
+  # end
 
-  def update
-  end
+  # def update
+  # end
 
   def pay
     # Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
@@ -47,10 +47,10 @@ class OrdersController < ApplicationController
 
   def done
     @item = Item.find(params[:id])
-    # if user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
-    # else
-    #   redirect_to root_path
-    # end
+    unless user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
+      redirect_to root_path
+    else
+    end
   end
 
   private

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -25,14 +25,20 @@ class OrdersController < ApplicationController
   end
 
   def pay
-    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-    Payjp::Charge.create(
-      amount: @item.price, #支払い金額
-      customer: @card.customer_id, #顧客ID
-      currency: 'jpy' #日本円
-    )
+    # Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+    # Payjp::Charge.create(
+    #   amount: @item.price, #支払い金額
+    #   customer: @card.customer_id, #顧客ID
+    #   currency: 'jpy' #日本円
+    # )
     @item.update(buyer_user_id: current_user.id) #購入者のIDを保存
     unless user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      Payjp::Charge.create(
+        amount: @item.price, #支払い金額
+        customer: @card.customer_id, #顧客ID
+        currency: 'jpy' #日本円
+      )
       redirect_to ({action: 'done', id: @item.id})  #購入完了画面に遷移
     else
     end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -39,6 +39,7 @@ class OrdersController < ApplicationController
     @item = Item.find(params[:id])
     if current_user.id != @item.saler_user_id && @item.transaction_status == 2
     else
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -32,7 +32,7 @@ class OrdersController < ApplicationController
 
   def done
     @item = Item.find(params[:id])
-    unless user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status != 1 && request.referer&.include?("/orders/#{@item.id}/new")
+    unless user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 2 && request.referer&.include?("/orders/#{@item.id}/new")
       redirect_to root_path
     else
     end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -41,11 +41,20 @@ class OrdersController < ApplicationController
   private
 
   def set_card
-    @card = Card.find_by(user_id: current_user.id) #credit_cards_controllerで使用したCardテーブルからpayjpの顧客IDを検索
+    @item = Item.find(params[:id])
+    if current_user.id == @item.saler_user_id && @item.transaction_status == 1
+      @card = Card.find_by(user_id: current_user.id) #credit_cards_controllerで使用したCardテーブルからpayjpの顧客IDを検索
+    else
+      redirect_to root_path
+    end
   end
 
   def set_item
     @item = Item.find(params[:id])
+    if current_user.id == @item.saler_user_id && @item.transaction_status == 1
+    else
+      redirect_to root_path
+    end
   end
 
 end

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -59,7 +59,6 @@
                     月
                 .new__card__create__formgroup__validatedDate__select__year
                   %select.new__card__create__formgroup__validatedDate__select__year__box{id: "exp_year", name: "exp_year", type: "text"}
-                    %option{value: "2020"} 20
                     %option{value: "2021"} 21
                     %option{value: "2022"} 22
                     %option{value: "2023"} 23
@@ -68,6 +67,9 @@
                     %option{value: "2026"} 26
                     %option{value: "2027"} 27
                     %option{value: "2028"} 28
+                    %option{value: "2029"} 29
+                    %option{value: "2030"} 30
+                    %option{value: "2031"} 31
                   %label
                     年
             .new__card__create__formgroup__securityNumber

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -87,7 +87,7 @@
             送料別
 
       .item__purchase
-        - if user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 1
+        - if user_signed_in? && current_user.id != @item.saler_user_id
           = link_to order_path(id: @item.id) do
             購入画面に進む
         - else

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -87,8 +87,8 @@
             送料別
 
       .item__purchase
-        - if user_signed_in? && current_user.id == @item.saler_user_id
-          = link_to "#" do
+        - if current_user.id != @item.saler_user_id
+          = link_to order_path(id: @item.id) do
             購入画面に進む
         - else
           = link_to new_user_session_path do

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -87,7 +87,7 @@
             送料別
 
       .item__purchase
-        - if user_signed_in? && current_user.id != @item.saler_user_id
+        - if user_signed_in? && current_user.id != @item.saler_user_id && @item.transaction_status == 1
           = link_to order_path(id: @item.id) do
             購入画面に進む
         - else

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -87,7 +87,7 @@
             送料別
 
       .item__purchase
-        - if current_user.id != @item.saler_user_id
+        - if user_signed_in? && current_user.id != @item.saler_user_id
           = link_to order_path(id: @item.id) do
             購入画面に進む
         - else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
   resources :sales, only: [:index]
   resources :points, only: [:index]
   resources :profiles, only: [:edit]
-  resources :orders, only: [:new, :edit, :update] do
+  resources :orders, only: [:new] do
     member do
       get 'new', to: 'orders#new'
       post 'pay', to: 'orders#pay'


### PR DESCRIPTION
# What
・「購入するボタン」で詳細画面から購入確認画面へ遷移するようにした。
・出品者またはtransaction_status == 1(出品ステータス)でない時に購入確認画面へ遷移できないようにした。(root_pathにリダイレクトされます。)
・購入したらtransaction_status == 2(購入済ステータス)になるようにした。(DB確認して下さい。)
・購入直後のみorders/商品id/doneに遷移できるようにした。(その他の場合root_pathにリダイレクトされます。)
・購入したら購入itemのbuyer_user_idが、購入したユーザのIDになるようにした。(DB確認して下さい。)
・購入された商品の詳細画面へ遷移できないようにした。(root_pathにリダイレクトされます。)

※詳細画面は/items/商品IDです。商品詳細から購入まのフローができます。
※テスト用クレジットカードは下記。

> カード番号：4242424242424242 (←pay.jpが推奨しているテストカード用の番号なので必ずこれを使ってください。)
> 有効期限：今より未来ならなんでも良い
> セキュリティコード：３桁ならなんでも良い

# Why
ページ遷移、エラーハンドリング対応。