### PR TITLE
本番環境でロゴが消える問題

### DIFF
--- a/app/assets/stylesheets/_profiles.scss
+++ b/app/assets/stylesheets/_profiles.scss
@@ -22,7 +22,7 @@
     line-height: 50px;
     .profile__background{
       height: 156px;
-      width: 700px;
+      width: 100%;
     }
   }
   &__main{

--- a/app/assets/stylesheets/_profiles.scss
+++ b/app/assets/stylesheets/_profiles.scss
@@ -20,6 +20,10 @@
     font-weight: 700;
     text-align: center;
     line-height: 50px;
+    .profile__background{
+      height: 156px;
+      width: 700px;
+    }
   }
   &__main{
     width: 100%;
@@ -27,7 +31,6 @@
     &__user{
       width: 100%;
       height: 156px;
-      background-image: url(profile_background.jpg);
       display: flex;
       justify-content: center;
      

--- a/app/assets/stylesheets/signup/_footer.scss
+++ b/app/assets/stylesheets/signup/_footer.scss
@@ -36,7 +36,7 @@
       &__image {
         height: 57px;
         width: 64px;
-        background: url('square_gray_logo.svg');
+        // background: url('square_gray_logo.svg');
         background-size: 63px;
       }
     }

--- a/app/assets/stylesheets/signup/_footer2.scss
+++ b/app/assets/stylesheets/signup/_footer2.scss
@@ -43,7 +43,7 @@
         &__image {
           height: 57px;
           width: 64px;
-          background: url('square_gray_logo.svg');
+          // background: url('square_gray_logo.svg');
           background-size: 63px;
         }
       }

--- a/app/assets/stylesheets/signup/_footerUserRegis.scss
+++ b/app/assets/stylesheets/signup/_footerUserRegis.scss
@@ -30,7 +30,7 @@
       &__image {
         height: 57px;
         width: 64px;
-        background: url('square_gray_logo.svg');
+        // background: url('square_gray_logo.svg');
         background-size: 63px;
       }
     }

--- a/app/assets/stylesheets/signup/_header.scss
+++ b/app/assets/stylesheets/signup/_header.scss
@@ -6,11 +6,10 @@
     justify-content: center;
     font-size: 70px;
     line-height: 80px;
-    transform: translateY(93.5%) translateX(-0.5%);
+    transform: translateY(40.5%) translateX(-0.5%);
     &__image {
       height: 54px;
       width: 184px;
-      background: url('fmarket_logo_red.svg');
       background-size: 184px;
     }
   }

--- a/app/assets/stylesheets/signup/_headerStep1.scss
+++ b/app/assets/stylesheets/signup/_headerStep1.scss
@@ -10,7 +10,7 @@
     &__image {
       height: 52px;
       width: 184px;
-      background: url('fmarket_logo_red.svg');
+      // background: url('fmarket_logo_red.svg');
       background-size: 184px;
     }
 

--- a/app/views/devise/registrations/create_card.html.haml
+++ b/app/views/devise/registrations/create_card.html.haml
@@ -1,7 +1,7 @@
 .header3
   .header3__logo
     = link_to root_path do
-      .header3__logo__image
+      =image_tag 'fmarket_logo_red.svg', class: 'header3__logo__image'
     .header3__logo__progress
       = image_tag "step4_r2.png", class: "image", size: "400x35"
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,7 +1,7 @@
 .header3
   .header3__logo
     = link_to root_path do
-      .header3__logo__image
+      =image_tag 'fmarket_logo_red.svg', class: 'header3__logo__image'
     .header3__logo__progress
       = image_tag "step1_r2.png", class: "image", size: "400x35"
 .contents3

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -1,7 +1,7 @@
 .header3
   .header3__logo
     = link_to root_path do
-      .header3__logo__image
+      =image_tag 'fmarket_logo_red.svg', class: 'header3__logo__image'
     .header3__logo__progress
       = image_tag "step3_r2.png", class: "image", size: "400x35"
 .contents5

--- a/app/views/devise/registrations/new_card.html.haml
+++ b/app/views/devise/registrations/new_card.html.haml
@@ -1,7 +1,7 @@
 .header3
   .header3__logo
     = link_to root_path do
-      .header3__logo__image
+      =image_tag 'fmarket_logo_red.svg', class: 'header3__logo__image'
     .header3__logo__progress
       = image_tag "step4_r2.png", class: "image", size: "400x35"
 

--- a/app/views/devise/registrations/new_cellphone.html.haml
+++ b/app/views/devise/registrations/new_cellphone.html.haml
@@ -1,7 +1,7 @@
 .header3
   .header3__logo
     = link_to root_path do
-      .header3__logo__image
+      =image_tag 'fmarket_logo_red.svg', class: 'header3__logo__image'
     .header3__logo__progress
       = image_tag "step2_r2.png", class: "image", size: "400x35"
 .contents4

--- a/app/views/devise/shared/_footer2.html.haml
+++ b/app/views/devise/shared/_footer2.html.haml
@@ -12,6 +12,6 @@
           特定商取引に関する表記
   .footer2__logo
     = link_to root_path do
-      .footer2__logo__image
+      =image_tag 'square_gray_logo.svg', class: 'footerUserRegis__logo__image'
   .footer2__inc
     ©︎ Fmarket, Inc.

--- a/app/views/devise/shared/_footerUserRegis.html.haml
+++ b/app/views/devise/shared/_footerUserRegis.html.haml
@@ -12,6 +12,6 @@
           特定商取引に関する表記
   .footerUserRegis__logo
     = link_to root_path do
-      .footerUserRegis__logo__image
+      =image_tag 'square_gray_logo.svg', class: 'footerUserRegis__logo__image'
   .footerUserRegis__inc
     ©︎ Fmarket, Inc.

--- a/app/views/devise/shared/_header2.html.haml
+++ b/app/views/devise/shared/_header2.html.haml
@@ -1,4 +1,5 @@
 .header2
   .header2__logo
     = link_to root_path do
-      .header2__logo__image
+      -# .header2__logo__image
+      =image_tag 'fmarket_logo_red.svg', class: 'header2__logo__image'

--- a/app/views/profiles/_profile.html.haml
+++ b/app/views/profiles/_profile.html.haml
@@ -4,12 +4,12 @@
   .profile
     .profile__head
       プロフィール
+      =image_tag 'profile_background.jpg', class: "profile__background"
     .profile__main
       .profile__main__user
         %figure
           =image_tag 'member_photo_noimage_thumb.png', class: "profile__icon"
         %input.nickname__fileld{:value => "nickname"}
-
       .profile__main__textBox
         %textarea.profile-comment{:placeholder=>"例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"}
         %button.edit__button{:tyle => "submit"} 変更する


### PR DESCRIPTION
# Why
![image](https://user-images.githubusercontent.com/58387687/77222994-c48e8980-6b9b-11ea-96bc-90a0994b9e1f.png)
本番環境の出品画面やサインアップ画面などでヘッダー・フッターのロゴが消える問題について、おそらくcssのbackground-imageでファイルを指定しているからと思われるので、hamlにimage_tagとして置き直しました。
（理由：root画面で使われているヘッダー・フッターでは表示されているのに、他では出なかったので、その差分を見たところ、前者はimage_tag、後者はcssで表記していたため。）

このブランチではローカルの状態は問題なかったので、早速マージして、本番環境で確認いただきたいです。