### PR TITLE
商品編集画面へのパス

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -100,7 +100,7 @@
   .container__manage
     .container__manage__box
       .container__manage__box__edit
-        =link_to '商品の編集', item_path(@item), method: :edit, class: "container__manage__box__text"
+        =link_to '商品の編集', edit_product_path(@item), class: "container__manage__box__text"
       %p.or or
       - if @item.transaction_status == 0
         .container__manage__box__resume


### PR DESCRIPTION
# What
商品詳細の商品編集ボタンを押すと編集画面に遷移するようにした

ログイン中のユーザーと出品者が違う時ルートパスに遷移する記述はここには記載していないが、
複数枚画像の商品編集機能#77に記載してます。
